### PR TITLE
Fix Node ID type

### DIFF
--- a/includes/types.php
+++ b/includes/types.php
@@ -30,8 +30,8 @@ add_action( 'graphql_register_types', function () {
 		return array_merge(
 			$fields,
 			[
-				'id' => [
-					'type'        => 'ID',
+                                'id' => [
+                                        'type'        => 'ID!',
 					'description' => sprintf(
 						/* translators: %s: SQL table name */
 						__( 'Relay‑compliant global ID derived from the primary key of %s.', 'wpgraphql-realtypress' ),


### PR DESCRIPTION
## Summary
- fix Node.id type mismatch by making it non-null

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684c431a0e7c8330bdd6c03f2cd2665f