### PR TITLE
Fix properties resolver preparing SQL with empty args

### DIFF
--- a/includes/loaders.php
+++ b/includes/loaders.php
@@ -48,12 +48,44 @@ if ( wprp_has_dataloader_api() ) {
     }
 
     /**
-     * Register our loader with WPGraphQL.
+     * DataLoader for Property records.
+     */
+    class PropertyLoader extends \WPGraphQL\Data\DataLoader\AbstractDataLoader {
+
+        /**
+         * Fetch a property row by ID.
+         *
+         * @param mixed $id
+         * @return array|null
+         */
+        public function load( $id ) {
+            global $wpdb;
+
+            $sql = $wpdb->prepare(
+                "SELECT * FROM {$wpdb->prefix}rps_property WHERE property_id = %d",
+                $id
+            );
+
+            return $wpdb->get_row( $sql, ARRAY_A );
+        }
+
+        /**
+         * Prime the cache (unused for now).
+         *
+         * @param mixed $id
+         * @param mixed $value
+         */
+        protected function prime( $id, $value ) {}
+    }
+
+    /**
+     * Register our loaders with WPGraphQL.
      */
     add_filter(
         'graphql_data_loaders',
         function ( array $loaders ) {
             $loaders['realty_board'] = RealtyBoardLoader::class;
+            $loaders['property']     = PropertyLoader::class;
             return $loaders;
         }
     );
@@ -63,7 +95,13 @@ if ( wprp_has_dataloader_api() ) {
     /**
      * Fallback stub so references to RealtyBoardLoader never fatal.
      */
-    class RealtyBoardLoader {
+class RealtyBoardLoader {
+        public function load( $id ) {
+            return null;
+        }
+    }
+
+    class PropertyLoader {
         public function load( $id ) {
             return null;
         }

--- a/includes/resolvers.php
+++ b/includes/resolvers.php
@@ -53,14 +53,18 @@ final class Resolvers {
 			$sql_args[] = $args['where']['minPrice'];
 		}
 
-		$where_sql = $where ? 'WHERE ' . implode( ' AND ', $where ) : '';
+                $sql = "SELECT property_id FROM {$wpdb->prefix}rps_property";
+                if ( $where ) {
+                        $sql .= ' WHERE ' . implode( ' AND ', $where );
+                }
 
-		// wpdb::prepare needs each placeholder passed separately.  We use
-		// the splat operator to expand the $sql_args array.
-		$sql = $wpdb->prepare(
-			"SELECT property_id FROM {$wpdb->prefix}rps_property {$where_sql}",
-			...$sql_args
-		);
+                // Only call wpdb::prepare when we actually have values to
+                // substitute, otherwise the method triggers a _doing_it_wrong
+                // warning. Expand $sql_args via the splat operator so each
+                // placeholder receives the correct value.
+                if ( $sql_args ) {
+                        $sql = $wpdb->prepare( $sql, ...$sql_args );
+                }
 
 		$ids = $wpdb->get_col( $sql );
 


### PR DESCRIPTION
## Summary
- avoid calling `$wpdb->prepare()` without arguments in the property connection resolver
- add `PropertyLoader` to fetch property records from the database

## Testing
- `pre-commit` *(fails: Codex couldn't run certain commands due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_b_684c497a968083309d4c85fc95cd01b7